### PR TITLE
Load environment variables from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/*.json
 data/*.csv
 data/*.txt
 src/assets/covers
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,6 +1817,12 @@
       "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.2.tgz",
       "integrity": "sha1-xzdwGfxOVQeYkosrmv62ar+h8vk="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
       "./tasks/lib/browserify-less",
       "./tasks/lib/browserify-text"
     ]
+  },
+  "devDependencies": {
+    "dotenv": "^8.2.0"
   }
 }

--- a/tasks/googleauth.js
+++ b/tasks/googleauth.js
@@ -30,6 +30,9 @@ var task = function(grunt) {
 
     var done = this.async();
 
+    // load environment variables from .env
+    require('dotenv').config()
+
     var clientID = process.env.GOOGLE_OAUTH_CLIENT_ID;
     var secret = process.env.GOOGLE_OAUTH_CONSUMER_SECRET;
 


### PR DESCRIPTION
Not sure if you'd like this, but it made it easier for me to specify the `GOOGLE_OAUTH_*` environment variables without having to type them in each time I needed to re-authenticate.