### PR TITLE
allows for both isbn and non-isbn covers

### DIFF
--- a/src/js/_cover.html
+++ b/src/js/_cover.html
@@ -8,7 +8,7 @@
   class="cover-link">
   <div class="cover-container" style="<%= aspect %>">
     <img 
-      <%= nativeLazy ? "src" : "data-src" %>="./assets/covers/<%= book.isbn %>.jpg"
+      <%= nativeLazy ? "src" : "data-src" %>="./assets/covers/<%= book.cover %>.jpg"
       class="cover"
       alt="<%= book.title %>"
       decoding="async"

--- a/tasks/shelve.js
+++ b/tasks/shelve.js
@@ -34,6 +34,11 @@ var shelve = async function(grunt) {
       if (isbn.length == 9) isbn = "0" + isbn;
       book.isbn = isbn;
 
+      // allows for both isbn and non-isbn cover images
+      var cover = String(book.cover).trim();
+      if (cover.length == 9) cover = "0" + cover;
+      book.cover = cover;
+
       // create 13-digit ISBN
       if (book.isbn.length == 13) {
         book.isbn13 = book.isbn;
@@ -57,11 +62,12 @@ var shelve = async function(grunt) {
         author: book.author,
         dimensions: {},
         isbn: book.isbn,
+        cover: book.cover,
         tags: book.tags,
         id: book.id
       };
       try {
-        var size = await imageSize(`src/assets/covers/${book.isbn}.jpg`);
+        var size = await imageSize(`src/assets/covers/${book.cover}.jpg`);
         indexEntry.dimensions = {
           width: size.width,
           height: size.height


### PR DESCRIPTION
followed the steps in this issue:
https://github.com/nprapps/book-concierge/issues/79

> Currently we link images to books by using the ISBN as an implicit key. We should make that explicit, so that we can support non-ISBN image names (for books that are non-mainstream published works).
> 
> 1. Create "cover" columns in the old sheet, and copy the ISBN into them.
> 2. Update the shelving code to propagate the cover column into the catalog JSON file.
> 3. Update the client-side code to look at the cover for creating the image tags.