### PR TITLE
Add multiple reviewers option for books and validate tests

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -99,7 +99,7 @@ The application expects to have access to a Google Doc with the text for the abo
 
   * ``id`` - primary key for the book, used for permalinks and table relationships
   * ``title``
-  * ``reviewer`` - this name should match the key in the reviewer sheet
+  * ``reviewers`` - an array of comma separated names should match keys in the reviewer sheet
   * ``text`` - recommendation blurb
   * ``tags`` - filter categories, separated by ``|`` characters
   * ``isbn``

--- a/src/js/_book.html
+++ b/src/js/_book.html
@@ -19,15 +19,16 @@
   <%= data.book.text %>
   <div class="reviewer">
     &mdash;
-    <% if (data.reviewer) { %>
-    <% (data.reviewer).forEach(function(rev, i) { %>
+    <% if (data.reviewers) { %>
+    <% (data.reviewers).forEach(function(rev, i) { %>
     <% if (rev.link) { %>
     <a href="<%= rev.link %>"><%= rev.key %></a>,
     <% } else { %>
     <%= rev.key %>,
     <% } %>
     <%= poorMD(rev.title || "NPR Staff") %>
-    <% if(i == 0) {%> and
+    <% if(data.reviewers.length - 2 == i) {%> and
+    <% } else if(i < data.reviewers.length - 1) { %>,
     <% } %>
     <% }); %>
     <% } %>

--- a/src/js/_book.html
+++ b/src/js/_book.html
@@ -19,19 +19,16 @@
   <%= data.book.text %>
   <div class="reviewer">
     &mdash;
-    <% if (data.reviewers) { %>
-    <% (data.reviewers).forEach(function(rev, i) { %>
-    <% if (rev.link) { %>
-    <a href="<%= rev.link %>"><%= rev.key %></a>,
-    <% } else { %>
-    <%= rev.key %>,
-    <% } %>
-    <%= poorMD(rev.title || "NPR Staff") %>
-    <% if(data.reviewers.length - 2 == i) {%> and
-    <% } else if(i < data.reviewers.length - 1) { %>,
-    <% } %>
+    <% if (data.reviewers) data.reviewers.forEach(function(rev, i) { 
+      var name = rev.link ? `<a href="${rev.link}">${rev.key}</a>` : rev.key;
+      var output = `${name}, ${poorMD(rev.title || "NPR Staff")}`;
+      if (i <= data.reviewers.length - 3) {
+        output += ", ";
+      } else if (i == data.reviewers.length - 2) {
+        output += " and ";
+      } %>
+      <%= output %>
     <% }); %>
-    <% } %>
   </div>
 </div>
 <ul class="links">

--- a/src/js/_book.html
+++ b/src/js/_book.html
@@ -19,12 +19,18 @@
   <%= data.book.text %>
   <div class="reviewer">
     &mdash;
-    <% if (data.reviewer.link) { %>
-    <a href="<%= data.reviewer.link %>"><%= data.book.reviewer %></a>,
+    <% if (data.reviewer) { %>
+    <% (data.reviewer).forEach(function(rev, i) { %>
+    <% if (rev.link) { %>
+    <a href="<%= rev.link %>"><%= rev.key %></a>,
     <% } else { %>
-    <%= data.book.reviewer %>,
+    <%= rev.key %>,
     <% } %>
-    <%= poorMD(data.reviewer.title || "NPR Staff") %>
+    <%= poorMD(rev.title || "NPR Staff") %>
+    <% if(i == 0) {%> and
+    <% } %>
+    <% }); %>
+    <% } %>
   </div>
 </div>
 <ul class="links">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -36,7 +36,7 @@ The hash is always the source of truth.
 
 var defaults = {
   view: "covers",
-  year: 2019
+  year: 2020
 };
 
 // hashes update filters (usually redundant) and render the main panel
@@ -78,7 +78,7 @@ channel.on("hashchange", async function(params, pastParams = {}) {
     // look up the reviewer from the table - inclues entries with two reviewers
     var all_rev = [];
     book.reviewers.forEach(function(rev){
-      one_rev = window.conciergeData.reviewers[rev] || {};
+      var one_rev = window.conciergeData.reviewers[rev] || {};
       all_rev.push(one_rev)
     });
     var reviewers = all_rev || {};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -79,14 +79,14 @@ channel.on("hashchange", async function(params, pastParams = {}) {
     
     // look up the reviewer from the table - inclues entries with two reviewers
     var all_rev = [];
-    book.reviewer_array.forEach(function(rev){
+    book.reviewers.forEach(function(rev){
       one_rev = window.conciergeData.reviewers[rev] || {};
       all_rev.push(one_rev)
     });
-    var reviewer = all_rev || {};
+    var reviewers = all_rev || {};
     
     track("book-selected", `${book.title} by ${book.author}`);
-    renderBook({ book, next, previous, back, hash, reviewer });
+    renderBook({ book, next, previous, back, hash, reviewers });
     document.body.setAttribute("data-mode", "book");
   } else {
     // filtered view rendering

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,8 +74,17 @@ channel.on("hashchange", async function(params, pastParams = {}) {
       tags: merged.tags,
       reset: !pastParams.year // don't restore focus if this is the starting view
     });
-    // look up the reviewer from the table
-    var reviewer = window.conciergeData.reviewers[book.reviewer] || {};
+    // look up the reviewer from the table - the single author way
+    // var reviewer = window.conciergeData.reviewers[book.reviewer] || {};
+    
+    // look up the reviewer from the table - inclues entries with two reviewers
+    var all_rev = [];
+    book.reviewer_array.forEach(function(rev){
+      one_rev = window.conciergeData.reviewers[rev] || {};
+      all_rev.push(one_rev)
+    });
+    var reviewer = all_rev || {};
+    
     track("book-selected", `${book.title} by ${book.author}`);
     renderBook({ book, next, previous, back, hash, reviewer });
     document.body.setAttribute("data-mode", "book");

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,8 +74,6 @@ channel.on("hashchange", async function(params, pastParams = {}) {
       tags: merged.tags,
       reset: !pastParams.year // don't restore focus if this is the starting view
     });
-    // look up the reviewer from the table - the single author way
-    // var reviewer = window.conciergeData.reviewers[book.reviewer] || {};
     
     // look up the reviewer from the table - inclues entries with two reviewers
     var all_rev = [];

--- a/tasks/shelve.js
+++ b/tasks/shelve.js
@@ -40,7 +40,7 @@ var shelve = async function(grunt) {
       book.cover = cover;
 
       // formats multiple reviewers into a comma seperated array
-      book.reviewer_array = book.reviewer.replace(/\s*,\s*/g, ",").split(',')
+      book.reviewers = book.reviewer.split(/,\s*/)
 
       // create 13-digit ISBN
       if (book.isbn.length == 13) {

--- a/tasks/shelve.js
+++ b/tasks/shelve.js
@@ -39,6 +39,9 @@ var shelve = async function(grunt) {
       if (cover.length == 9) cover = "0" + cover;
       book.cover = cover;
 
+      // formats multiple reviewers into a comma seperated array
+      book.reviewer_array = book.reviewer.replace(/\s*,\s*/g, ",").split(',')
+
       // create 13-digit ISBN
       if (book.isbn.length == 13) {
         book.isbn13 = book.isbn;

--- a/tasks/shelve.js
+++ b/tasks/shelve.js
@@ -29,7 +29,7 @@ var shelve = async function(grunt) {
       book.year = year;
       book.tags = normalizeTags(book.tags || "");
       book.text = grunt.template.renderMarkdown(book.text || "");
-      "title author reviewer text".split(" ").forEach(p => book[p] = book[p].toString().trim());
+      "title author reviewers text".split(" ").forEach(p => book[p] = book[p].toString().trim());
       var isbn = String(book.isbn).trim();
       if (isbn.length == 9) isbn = "0" + isbn;
       book.isbn = isbn;
@@ -40,8 +40,7 @@ var shelve = async function(grunt) {
       book.cover = cover;
 
       // formats multiple reviewers into a comma seperated array
-      book.reviewers = book.reviewer.split(/,\s*/)
-      delete book.reviewer
+      book.reviewers = book.reviewers.split(/,\s*/)
 
       // create 13-digit ISBN
       if (book.isbn.length == 13) {

--- a/tasks/shelve.js
+++ b/tasks/shelve.js
@@ -41,6 +41,7 @@ var shelve = async function(grunt) {
 
       // formats multiple reviewers into a comma seperated array
       book.reviewers = book.reviewer.split(/,\s*/)
+      delete book.reviewer
 
       // create 13-digit ISBN
       if (book.isbn.length == 13) {

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -97,7 +97,7 @@ module.exports = function(grunt) {
     // Are all reviewers used somewhere?
     var passed = true;
     Object.keys(grunt.data.json.reviewers).forEach(function(reviewer) {
-      var matched = grunt.data.shelf.some(book => book.reviewer == reviewer);
+      var matched = grunt.data.shelf.some(book => (book.reviewer_array.includes(reviewer)));
       if (!matched) {
         console.log(`Reviewer ${reviewer} has no reviewed books.`);
         passed = false;
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
 
   var reviewed = async function() {
     // Do all books have a valid reviewer?
-    var noReviewer = grunt.data.shelf.filter(b => !(b.reviewer in grunt.data.json.reviewers));
+    var noReviewer = grunt.data.shelf.filter(b => !(b.reviewer_array[0] in grunt.data.json.reviewers || b.reviewer_array[1] in grunt.data.json.reviewers));
     noReviewer.forEach(b => console.log(`Book "${b.title}" (${b.year}) doesn't have a valid reviewer (${b.reviewer}).`));
     return !noReviewer.length;
   };

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -97,7 +97,7 @@ module.exports = function(grunt) {
     // Are all reviewers used somewhere?
     var passed = true;
     Object.keys(grunt.data.json.reviewers).forEach(function(reviewer) {
-      var matched = grunt.data.shelf.some(book => (book.reviewer_array.includes(reviewer)));
+      var matched = grunt.data.shelf.some(book => (book.reviewers.includes(reviewer)));
       if (!matched) {
         console.log(`Reviewer ${reviewer} has no reviewed books.`);
         passed = false;
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
 
   var reviewed = async function() {
     // Do all books have a valid reviewer?
-    var noReviewer = grunt.data.shelf.filter(b => !(b.reviewer_array[0] in grunt.data.json.reviewers || b.reviewer_array[1] in grunt.data.json.reviewers));
+    var noReviewer = grunt.data.shelf.filter(b => !(b.reviewers.every(r => r in grunt.data.json.reviewers)));
     noReviewer.forEach(b => console.log(`Book "${b.title}" (${b.year}) doesn't have a valid reviewer (${b.reviewer}).`));
     return !noReviewer.length;
   };

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
         console.log(`Book #${book.id} in ${book.year} ("${book.title}") has a duplicate ID`);
       }
       yearIDs[book.year].add(book.id);
-      "title text reviewer tags isbn".split(" ").forEach(function(p) {
+      "title text reviewers tags isbn".split(" ").forEach(function(p) {
         if (!book[p]) {
           passed = false;
           console.log(`Book #${book.id} (${book.year}) is missing property "${p}"`);
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
   var reviewed = async function() {
     // Do all books have a valid reviewer?
     var noReviewer = grunt.data.shelf.filter(b => !(b.reviewers.every(r => r in grunt.data.json.reviewers)));
-    noReviewer.forEach(b => console.log(`Book "${b.title}" (${b.year}) doesn't have a valid reviewer (${b.reviewer}).`));
+    noReviewer.forEach(b => console.log(`Book "${b.title}" (${b.year}) doesn't have a valid reviewer (${b.reviewers}).`));
     return !noReviewer.length;
   };
 


### PR DESCRIPTION
PR for https://github.com/nprapps/book-concierge/issues/78

> This year we may have items where a book is reviewed by multiple people. We should be able to set the reviewer field to a comma-separated list, and have it output that as a set of linked name/title strings.

> Update the shelving and validation code so that they support an array of reviewers, not a single reviewer.
> Update the client-side code to join these reviewers in a loop