### PR TITLE
switch to scrolling year display in header sooner to prevent linebreak

### DIFF
--- a/src/css/header.less
+++ b/src/css/header.less
@@ -155,7 +155,7 @@ header.hero {
     display: flex;
     flex-wrap: nowrap;
 
-    @media @tablet-above {
+    @media @year-scroll-above {
       padding-top: 22px;
       display: block;
     }
@@ -179,7 +179,7 @@ header.hero {
         text-align: center;
         font-size: 11px;
 
-        @media @tablet {
+        @media @year-scroll {
           display: inline-block;
           margin-bottom: -8px;
           width: floor((100% / 9) - 1);
@@ -191,7 +191,7 @@ header.hero {
           font-size: 14px;
         }
 
-        @media @tablet-above {
+        @media @year-scroll-above {
           padding: 10px 15px;
         }
       }
@@ -218,7 +218,7 @@ header.hero {
 
   // Scrollable tabs on smaller screens
   .years-container {
-    @media @tablet {
+    @media @year-scroll {
       // Make scrollable
       overflow-x: scroll;
       overflow-y: hidden;

--- a/src/css/values.less
+++ b/src/css/values.less
@@ -6,6 +6,10 @@
 @desktop: ~"(max-width: 1000px)";
 @desktop-above: ~"(min-width: 1001px)";
 
+// Year scroll width fix
+@year-scroll: ~"(max-width: 830px)";
+@year-scroll-above: ~"(min-width: 830.1px)";
+
 // Fonts
 @gotham: 'Gotham SSm', Helvetica, Arial, sans-serif;
 @knockout: 'Knockout 31 4r','Helvetica Neue', 'Helvetica', 'Arial', sans-serif;


### PR DESCRIPTION
fixes #117

I only changed the style for the year menu, not the background so we get to keep the illustration on screen a bit longer.

